### PR TITLE
Remove petclinic.database property

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -4,7 +4,6 @@
 server.port: 0
 
 # embedded database init, supports mysql too trough the 'mysql' spring profile
-petclinic.database: hsqldb
 spring:
   datasource:
     schema: classpath*:db/hsqldb/schema.sql


### PR DESCRIPTION
I'm not sure, but I believe that the `petclinic.database` property is not used
Switch between MySQL and HSQLDB databases is using Spring profiles.