### PR TITLE
Update application.yaml for mysql in docker

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -4,7 +4,6 @@
 server.port: 0
 
 # embedded database init, supports mysql too trough the 'mysql' spring profile
-petclinic.database: hsqldb
 spring:
   datasource:
     schema: classpath*:db/hsqldb/schema.sql
@@ -52,6 +51,18 @@ spring:
     schema: classpath*:db/mysql/schema.sql
     data: classpath*:db/mysql/data.sql
     url: jdbc:mysql://localhost:3306/petclinic?useSSL=false
+    username: root
+    password: petclinic
+    initialization-mode: ALWAYS
+---
+spring:
+  profiles: 
+    - mysql
+    - docker
+  datasource:
+    schema: classpath*:db/mysql/schema.sql
+    data: classpath*:db/mysql/data.sql
+    url: jdbc:mysql://mysql-db:3306/petclinic?useSSL=false
     username: root
     password: petclinic
     initialization-mode: ALWAYS


### PR DESCRIPTION
By updating Dockerfile to include mysql as an active profile, services will now connect to a mysql docker container spun up as part of docker-compose up.