### PR TITLE
Spring Boot configuration syntax migration

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -8,9 +8,10 @@ server:
 
 # embedded database init, supports mysql too trough the 'mysql' spring profile
 spring:
-  datasource:
-    schema: classpath*:db/hsqldb/schema.sql
-    data: classpath*:db/hsqldb/data.sql
+  sql:
+    init:
+      schema-locations: classpath*:db/hsqldb/schema.sql
+      data-locations: classpath*:db/hsqldb/data.sql
   sleuth:
     sampler:
       probability: 1.0
@@ -77,9 +78,11 @@ spring:
     activate:
       on-profile: mysql
   datasource:
-    schema: classpath*:db/mysql/schema.sql
-    data: classpath*:db/mysql/data.sql
     url: jdbc:mysql://localhost:3306/petclinic?useSSL=false
     username: root
     password: petclinic
-    initialization-mode: ALWAYS
+  sql:
+    init:
+      schema-locations: classpath*:db/mysql/schema.sql
+      data-locations: classpath*:db/mysql/data.sql
+      init: ALWAYS

--- a/customers-service.yml
+++ b/customers-service.yml
@@ -1,5 +1,7 @@
 ﻿spring:
-  profiles: default
+  config:
+    activate:
+      on-profile: default
 eureka:
   instance:
     # enable to register multiple app instances with a random server port

--- a/visits-service.yml
+++ b/visits-service.yml
@@ -1,5 +1,7 @@
 ﻿spring:
-  profiles: default
+  config:
+    activate:
+      on-profile: default
 eureka:
   instance:
     # enable to register multiple app instances with a random server port


### PR DESCRIPTION
Use new Spring Boot properties `spring.init.sql` and `spring.ativate.on-profile` that are compatibles with Spring Boot 2.6, 2.7 and 3.0:
https://docs.spring.io/spring-boot/docs/2.6.x/reference/html/application-properties.html
https://docs.spring.io/spring-boot/docs/3.0.x/reference/html/application-properties.html