### PR TITLE
Fix Eureka registering unreachable hostname on Windows

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -58,6 +58,11 @@ management:
     sampling:
       probability: 1
 
+eureka:
+  instance:
+    # Register IP address instead of hostname to avoid resolution failures on Windows
+    prefer-ip-address: true
+
 # Chaos Engineering
 ---
 spring:


### PR DESCRIPTION
## Summary

- Add `eureka.instance.prefer-ip-address: true` to the shared `application.yml` so all microservices register their IP address in Eureka instead of the system hostname
- On Windows, the hostname is often unresolvable from other containers, causing routing failures when services try to communicate via the gateway
- Centralising this in the config server avoids repeating the setting in each microservice's local `application.yml`

Fixes spring-petclinic/spring-petclinic-microservices#487

## Test plan

- [ ] Run `docker-compose up` on Windows and verify all services register with an IP address in the Eureka dashboard (`http://localhost:8761`)
- [ ] Verify inter-service calls succeed (e.g. api-gateway → customers-service)