### PR TITLE
move Zipkin endpoint to docker profile to resolve local startup errors

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -57,9 +57,6 @@ management:
   tracing:
     sampling:
       probability: 1
-    export:
-      zipkin:
-        endpoint: "http://tracing-server:9411/api/v2/spans"
 
 eureka:
   instance:
@@ -82,6 +79,17 @@ chaos:
       repository: false
       rest-controller: false
       service: false
+
+---
+spring:
+  config:
+    activate:
+      on-profile: docker
+management:
+  tracing:
+    export:
+      zipkin:
+        endpoint: "http://tracing-server:9411/api/v2/spans"
 
 ---
 spring:


### PR DESCRIPTION
This prevents UnresolvedAddressException during local development while maintaining functional tracing in Docker.