### PR TITLE
fix: zipkin traces in local envirornment

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -57,9 +57,9 @@ management:
   tracing:
     sampling:
       probability: 1
-    export:
-      zipkin:
-        endpoint: "http://tracing-server:9411/api/v2/spans"
+  export:
+    zipkin:
+      endpoint: "http://127.0.0.1:9411/zipkin/"
 
 eureka:
   instance:
@@ -82,6 +82,17 @@ chaos:
       repository: false
       rest-controller: false
       service: false
+
+---
+spring:
+  config:
+    activate:
+      on-profile: docker
+management:
+  tracing:
+    export:
+      zipkin:
+        endpoint: "http://tracing-server:9411/api/v2/spans"
 
 ---
 spring:

--- a/application.yml
+++ b/application.yml
@@ -57,9 +57,6 @@ management:
   tracing:
     sampling:
       probability: 1
-  export:
-    zipkin:
-      endpoint: "http://127.0.0.1:9411/zipkin/"
 
 eureka:
   instance:


### PR DESCRIPTION
moved docker endpoint to docker profile and removed the default endpoint, because spring-boot-starter-zipkin auto-configures the default endpoint to http://localhost:9411/api/v2/spans when nothing is specified. now when services are started locally in IDE and zipkin in docker, traces are shown in dashboard. 

to start zipkin container separateley and match container port and host port we use 
"docker run -d -p 9411:9411 openzipkin/zipkin" → Zipkin listens on localhost:9411

we need to update readme.md